### PR TITLE
유저 중복, 이메일 유효성 검사 테스트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 .vscode/
 application.properties
 /MyPlaceAuth/
+/spy.log

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-MyPlaceSecurity
+MyPlaceAuth
 !**/src/main/resources/application.properties
 
 ### STS ###
@@ -38,3 +38,4 @@ out/
 ### VS Code ###
 .vscode/
 application.properties
+/MyPlaceAuth/

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testCompileOnly 'org.assertj:assertj-core'

--- a/src/main/java/myplace/core/CoreApplication.java
+++ b/src/main/java/myplace/core/CoreApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@PropertySource("file:C:/Users/finge/IdeaProjects/core/MyPlaceSecurity/application.properties")
+@PropertySource("file:C:/Users/finge/IdeaProjects/core/MyPlaceAuth/application-main.yml")
 @EnableJpaAuditing
 @SpringBootApplication
 public class CoreApplication {

--- a/src/main/java/myplace/core/user/dao/UserRepository.java
+++ b/src/main/java/myplace/core/user/dao/UserRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    List<User> findDistinctUserByEmailAndName(String email, String name);
+    List<User> findDistinctUserByEmailAndUsername(String email, String username);
 
     User findDistinctUserByName(String name);
 

--- a/src/main/java/myplace/core/user/dao/UserRepository.java
+++ b/src/main/java/myplace/core/user/dao/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findDistinctUserByEmailAndName(String email, String name);
+
+    User findDistinctUserByName(String name);
 }

--- a/src/main/java/myplace/core/user/dao/UserRepository.java
+++ b/src/main/java/myplace/core/user/dao/UserRepository.java
@@ -11,4 +11,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findDistinctUserByEmailAndName(String email, String name);
 
     User findDistinctUserByName(String name);
+
+    User findDistinctById(Long id);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/myplace/core/user/dto/UserDto.java
+++ b/src/main/java/myplace/core/user/dto/UserDto.java
@@ -6,7 +6,6 @@ import myplace.core.user.domain.User;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
-import java.util.Date;
 
 @Getter
 @Setter

--- a/src/main/java/myplace/core/user/dto/UserDto.java
+++ b/src/main/java/myplace/core/user/dto/UserDto.java
@@ -30,7 +30,7 @@ public class UserDto {
     private String email;
 
     @Builder
-    public UserDto(Long id, String name, String username, String password, String email, Date createdAt) {
+    public UserDto(Long id, String name, String username, String password, String email) {
         this.id = id;
         this.name = name;
         this.username = username;

--- a/src/main/java/myplace/core/user/dto/UserDto.java
+++ b/src/main/java/myplace/core/user/dto/UserDto.java
@@ -3,9 +3,7 @@ package myplace.core.user.dto;
 import lombok.*;
 import myplace.core.user.domain.User;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
 
 @Getter
 @Setter
@@ -13,19 +11,19 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 public class UserDto {
     private Long id;
-    @NotEmpty(message = "이름은 필수항목입니다.")
+    @NotBlank(message = "이름은 필수항목입니다.")
     private String name;
 
     @Size(min = 4, message = "닉네임은 4글자 이상이어야 합니다")
-    @NotEmpty(message = "닉네임은 필수항목입니다.")
+    @NotBlank(message = "닉네임은 필수항목입니다.")
     private String username;
 
-    @NotEmpty(message = "비밀번호는 필수항목입니다.")
+    @NotBlank(message = "비밀번호는 필수항목입니다.")
     @Size(min = 8, max = 20, message = "비밀번호는 8자리 이상이어야 합니다.")
     private String password;
 
     @Email
-    @NotEmpty(message = "이메일은 필수항목입니다.")
+    @NotBlank(message = "이메일은 필수항목입니다.")
     private String email;
 
     @Builder

--- a/src/main/java/myplace/core/user/dto/UserDto.java
+++ b/src/main/java/myplace/core/user/dto/UserDto.java
@@ -14,14 +14,15 @@ import java.util.Date;
 @NoArgsConstructor
 public class UserDto {
     private Long id;
-    @Size(min = 3, max = 25)
     @NotEmpty(message = "이름은 필수항목입니다.")
     private String name;
 
+    @Size(min = 4, message = "닉네임은 4글자 이상이어야 합니다")
     @NotEmpty(message = "닉네임은 필수항목입니다.")
     private String username;
 
     @NotEmpty(message = "비밀번호는 필수항목입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자리 이상이어야 합니다.")
     private String password;
 
     @Email

--- a/src/main/java/myplace/core/user/service/UserService.java
+++ b/src/main/java/myplace/core/user/service/UserService.java
@@ -1,9 +1,9 @@
 package myplace.core.user.service;
 
 import lombok.AllArgsConstructor;
+import myplace.core.user.dao.UserRepository;
 import myplace.core.user.domain.User;
 import myplace.core.user.dto.UserDto;
-import myplace.core.user.dao.UserRepository;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -15,7 +15,6 @@ import java.util.List;
 public class UserService {
     private UserRepository userRepository;
 
-
     public Long saveUser(UserDto userDto) {
         return userRepository.save(userDto.toEntity()).getId();
     }
@@ -23,4 +22,7 @@ public class UserService {
     public List<User> findUsers() {
         return userRepository.findAll();
     }
+
+    public User findOne(Long userId){
+        return userRepository.findDistinctById(userId);}
 }

--- a/src/main/java/myplace/core/user/service/UserService.java
+++ b/src/main/java/myplace/core/user/service/UserService.java
@@ -16,6 +16,7 @@ public class UserService {
     private UserRepository userRepository;
 
     public Long saveUser(UserDto userDto) {
+        validateDuplicateUser(userDto.toEntity());
         return userRepository.save(userDto.toEntity()).getId();
     }
 
@@ -23,6 +24,12 @@ public class UserService {
         return userRepository.findAll();
     }
 
+    public void validateDuplicateUser(User user) {
+        List<User> findUsers = userRepository.findDistinctUserByEmailAndUsername(user.getEmail(), user.getUsername());
+        if (!findUsers.isEmpty()) {
+            throw new IllegalStateException("이미 존재하는 회원입니다.");
+        }
+    }
     public User findOne(Long userId){
         return userRepository.findDistinctById(userId);}
 }

--- a/src/test/java/myplace/core/user/dao/UserRepositoryTest.java
+++ b/src/test/java/myplace/core/user/dao/UserRepositoryTest.java
@@ -1,15 +1,12 @@
 package myplace.core.user.dao;
 
 import myplace.core.user.domain.User;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
 
 import javax.transaction.Transactional;
-import java.sql.Timestamp;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/myplace/core/user/dao/UserRepositoryTest.java
+++ b/src/test/java/myplace/core/user/dao/UserRepositoryTest.java
@@ -21,20 +21,20 @@ public class UserRepositoryTest {
     @Test
     @DisplayName("유저 생성 확인")
     public void create_user() {
-        String name = "daniel";
+        String username = "dkinda";
         String email = "kbry12@naver.com";
 
         userRepository.save(User.builder()
                 .id(1L)
-                .username("dkinda")
-                .name(name)
+                .username(username)
+                .name("daniel")
                 .email(email)
                 .password("1234")
                 .build());
 
-        List<User> userList = userRepository.findDistinctUserByEmailAndName(email, name);
+        List<User> userList = userRepository.findDistinctUserByEmailAndUsername(email, username);
         User user = userList.get(0);
-        assertThat(user.getName()).isEqualTo("daniel");
+        assertThat(user.getUsername()).isEqualTo(username);
         assertThat(user.getEmail()).isEqualTo("kbry12@naver.com");
     }
 }

--- a/src/test/java/myplace/core/user/dao/UserRepositoryTest.java
+++ b/src/test/java/myplace/core/user/dao/UserRepositoryTest.java
@@ -12,11 +12,12 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@Transactional
 public class UserRepositoryTest {
     @Autowired
     UserRepository userRepository;
 
-    @Transactional
+
     @Test
     @DisplayName("유저 생성 확인")
     public void create_user() {

--- a/src/test/java/myplace/core/user/dao/UserRepositoryTest.java
+++ b/src/test/java/myplace/core/user/dao/UserRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 import javax.transaction.Transactional;
 import java.sql.Timestamp;

--- a/src/test/java/myplace/core/user/dto/UserEmailValidationTest.java
+++ b/src/test/java/myplace/core/user/dto/UserEmailValidationTest.java
@@ -1,0 +1,44 @@
+package myplace.core.user.dto;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+@SpringBootTest
+@Transactional
+public class UserEmailValidationTest {
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+    @Test
+    public void 유저_이메일_유효성_검사() throws Exception {
+        //given
+        String email = "startscream@";
+
+
+        UserDto userDto = new UserDto();
+        userDto.setEmail(email);
+        userDto.setName("alex");
+        userDto.setUsername("alexy");
+        userDto.setPassword("12561gae");
+
+        //when
+        Set<ConstraintViolation<UserDto>> violations = validator.validate(userDto);
+        System.out.println(violations);
+
+        //then
+        assertEquals(1, violations.size());
+    }
+}

--- a/src/test/java/myplace/core/user/service/UserServiceTest.java
+++ b/src/test/java/myplace/core/user/service/UserServiceTest.java
@@ -1,0 +1,35 @@
+package myplace.core.user.service;
+
+import myplace.core.user.dao.UserRepository;
+import myplace.core.user.dto.UserDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@Transactional
+public class UserServiceTest {
+    @Autowired
+    UserService userService;
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    public void 중복회원_검사_이메일_유저닉네임() throws Exception {
+        //given
+        String email = "asc@goo.com";
+        String username = "darkmode";
+        UserDto user1 = UserDto.builder().email(email).username(username).build();
+
+        UserDto user2 = UserDto.builder().email(email).username(username).build();
+        //when
+        userService.saveUser(user1);
+
+        //then
+        assertThrows(IllegalStateException.class, () -> {
+           userService.saveUser(user2);
+        });
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+
+logging:
+  level:
+    org.hibernate.sql: debug

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,7 +13,7 @@ spring:
         show_sql: true
         format_sql: true
 
-
-logging:
-  level:
-    org.hibernate.sql: debug
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true


### PR DESCRIPTION
수정사항
* `in-memory h2`를 적용하여 기존의 데이터베이스와 겹치지 않도록 테스트 수정
* 유저 중복용 `UserServiceTest` 및 이메일 유효성 검사 확인용 `UserEmailValidationTest` 추가
* `UserDto` `@NotEmpty` 였던 annotation들 모두 `@NotBlank`로 수정. 기존의 `@NotEmpty`는 " " (빈 문자열)을 놓치기 때문에 위처럼 수정하였습니다.
* 테스트 설정 및 기존의 어플리케이션 설정을 모두 `yml` 형식으로 교체
* `p6spy` 적용하여 개발 중 쿼리 확인을 더 쉽게 할 수 있도록 변경하였습니다.